### PR TITLE
Expose "Client" field of Reference

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -20,7 +20,7 @@ type client interface {
 type Reference struct {
 	url          string
 	postfix      string
-	client       client
+	Client       client
 	token        string
 	export       bool
 	response     *http.Response
@@ -35,7 +35,7 @@ func NewReference(url string) *Reference {
 		url:     url,
 		postfix: ".json",
 		export:  false,
-		client:  &http.Client{},
+		Client:  &http.Client{},
 	}
 
 	return r
@@ -85,7 +85,7 @@ func (r *Reference) executeRequest(method string, body []byte) ([]byte, error) {
 	}
 
 	// Make actual HTTP request.
-	if r.response, err = r.client.Do(req); err != nil {
+	if r.response, err = r.Client.Do(req); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +97,7 @@ func (r *Reference) executeRequest(method string, body []byte) ([]byte, error) {
 
 		location := r.response.Header.Get("Location")
 		req, err = http.NewRequest(method, location, bytes.NewReader(body))
-		if r.response, err = r.client.Do(req); err != nil {
+		if r.response, err = r.Client.Do(req); err != nil {
 			return nil, err
 		}
 	}

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -67,7 +67,7 @@ func TestThatWriteWorks(t *testing.T) {
 	r := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "200 OK"},
+		Client:  &MockClient{person, "200 OK"},
 	}
 
 	err = r.Write(person)
@@ -78,7 +78,7 @@ func TestThatWriteWorks(t *testing.T) {
 	rn := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "404 Not Found"},
+		Client:  &MockClient{person, "404 Not Found"},
 	}
 
 	err = rn.Write(person)
@@ -100,7 +100,7 @@ func TestThatUpdateWorks(t *testing.T) {
 	r := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "200 OK"},
+		Client:  &MockClient{person, "200 OK"},
 	}
 
 	err = r.Update(person)
@@ -111,7 +111,7 @@ func TestThatUpdateWorks(t *testing.T) {
 	rn := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "404 Not Found"},
+		Client:  &MockClient{person, "404 Not Found"},
 	}
 
 	err = rn.Update(person)
@@ -133,7 +133,7 @@ func TestThatPushWorks(t *testing.T) {
 	r := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "200 OK"},
+		Client:  &MockClient{person, "200 OK"},
 	}
 
 	err = r.Push(person)
@@ -144,7 +144,7 @@ func TestThatPushWorks(t *testing.T) {
 	rn := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "404 Not Found"},
+		Client:  &MockClient{person, "404 Not Found"},
 	}
 
 	err = rn.Push(person)
@@ -163,7 +163,7 @@ func TestThatDeleteWorks(t *testing.T) {
 	r := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "200 OK"},
+		Client:  &MockClient{person, "200 OK"},
 	}
 
 	err = r.Delete()
@@ -174,7 +174,7 @@ func TestThatDeleteWorks(t *testing.T) {
 	rn := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "404 Not Found"},
+		Client:  &MockClient{person, "404 Not Found"},
 	}
 
 	err = rn.Delete()
@@ -196,7 +196,7 @@ func TestThatValueWorks(t *testing.T) {
 	r := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "200 OK"},
+		Client:  &MockClient{person, "200 OK"},
 	}
 
 	norsep := StubPerson{}
@@ -213,7 +213,7 @@ func TestThatValueWorks(t *testing.T) {
 	rn := &Reference{
 		url:     url,
 		postfix: ".json",
-		client:  &MockClient{person, "404 Not Found"},
+		Client:  &MockClient{person, "404 Not Found"},
 	}
 
 	norsep2 := StubPerson{}


### PR DESCRIPTION
This is just an idea. glad you think about that ;)

---

Because, in some environment, using http.DefaultClient is not allowed and we might want to replace http client with custom http client; e.g. https://godoc.org/google.golang.org/appengine/urlfetch#Client

---

Options otherwise

1. Extend "NewReference" func so that it can accept more configs for ref
2. Create "SetClient" setter-method so that we can replace client specifically